### PR TITLE
feat: Replace DOM usage with mitt pub-sub

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-preset-react": "^6.23.0",
     "codacy-coverage": "^2.0.1",
     "gh-pages": "^0.12.0",
+    "mitt": "^1.1.0",
     "mousetrap": "^1.6.0",
     "react": "next",
     "react-dom": "next",

--- a/src/lib/Manager.js
+++ b/src/lib/Manager.js
@@ -42,18 +42,18 @@ export default class Manager {
   }
 
   mount() {
-    this._bus.addEventListener('fill-mount', this.handleFillMount);
-    this._bus.addEventListener('fill-updated', this.handleFillUpdated);
-    this._bus.addEventListener('fill-unmount', this.handleFillUnmount);
+    this._bus.on('fill-mount', this.handleFillMount);
+    this._bus.on('fill-updated', this.handleFillUpdated);
+    this._bus.on('fill-unmount', this.handleFillUnmount);
   }
 
   unmount() {
-    this._bus.removeEventListener('fill-mount', this.handleFillMount);
-    this._bus.removeEventListener('fill-updated', this.handleFillUpdated);
-    this._bus.removeEventListener('fill-unmount', this.handleFillUnmount);
+    this._bus.off('fill-mount', this.handleFillMount);
+    this._bus.off('fill-updated', this.handleFillUpdated);
+    this._bus.off('fill-unmount', this.handleFillUnmount);
   }
 
-  handleFillMount({ detail: { fill } }) {
+  handleFillMount({ fill }) {
     const elements = Children.toArray(fill.props.children);
     const name = fill.props.name;
     const component = { fill, elements, name };
@@ -75,7 +75,7 @@ export default class Manager {
       fn(this._db.byName[name].components));
   }
 
-  handleFillUpdated({ detail: { fill } }) {
+  handleFillUpdated({ fill }) {
     // Find the component
     const component = this._db.byFill.get(fill);
 
@@ -93,7 +93,7 @@ export default class Manager {
     });
   }
 
-  handleFillUnmount({ detail: { fill } }) {
+  handleFillUnmount({ fill }) {
     const oldComponent = this._db.byFill.get(fill);
 
     const name = oldComponent.name;

--- a/src/lib/components/Fill.js
+++ b/src/lib/components/Fill.js
@@ -4,27 +4,21 @@ import { busShape } from '../utils/PropTypes';
 
 export default class Fill extends React.Component {
   componentWillMount() {
-    this.context.bus.dispatchEvent(new CustomEvent('fill-mount', {
-      detail: {
-        fill: this
-      }
-    }));
+    this.context.bus.emit('fill-mount', {
+      fill: this
+    });
   }
 
   componentDidUpdate() {
-    this.context.bus.dispatchEvent(new CustomEvent('fill-updated', {
-      detail: {
-        fill: this,
-      }
-    }));
+    this.context.bus.emit('fill-updated', {
+      fill: this
+    });
   }
 
   componentWillUnmount() {
-    this.context.bus.dispatchEvent(new CustomEvent('fill-unmount', {
-      detail: {
-        fill: this,
-      }
-    }))
+    this.context.bus.emit('fill-unmount', {
+      fill: this
+    })
   }
 
   render() {

--- a/src/lib/components/Provider.js
+++ b/src/lib/components/Provider.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import mitt from 'mitt';
 
 import { managerShape, busShape } from '../utils/PropTypes';
 import Manager from '../Manager';
@@ -7,7 +8,7 @@ import Manager from '../Manager';
 export default class Provider extends React.Component {
   constructor() {
     super();
-    this._bus = document.createElement('div'); // Probably a bad pub-sub
+    this._bus = mitt();
     this._manager = new Manager(this._bus);
     this._manager.mount();
   }

--- a/src/lib/utils/PropTypes.js
+++ b/src/lib/utils/PropTypes.js
@@ -6,5 +6,7 @@ export const managerShape = PropTypes.shape({
 });
 
 export const busShape = PropTypes.shape({
-  dispatchEvent: PropTypes.func.isRequired
+  emit: PropTypes.func.isRequired,
+  on: PropTypes.func.isRequired,
+  off: PropTypes.func.isRequired
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,6 +3583,10 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mitt@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.1.0.tgz#22f0d57e2fedd39620a62bb41b7cdd93667d3c41"
+
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"


### PR DESCRIPTION
This replaces the current `document.createElement` faux pub-sub with a standard pub-sub dependency.

* [mitt](https://github.com/developit/mitt) is a mini pub-sub library that has the same interace as the [Node.EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class
* Replaces the need for a faux pub-sub via DOM node i.e. `document.createElement`
* Should allow us to use this for server-side rendering now without the need for JSDOM etc.
* Removed the `detail` sub-object in the event payload, can just use `fill` now.