### PR TITLE
Use `{}` instead of `void` for component state to avoid build errors.

### DIFF
--- a/src/lib/components/Fill.ts
+++ b/src/lib/components/Fill.ts
@@ -8,7 +8,7 @@ export interface Props {
   [key: string]: any;
 }
 
-export default class Fill extends React.Component<Props, void> {
+export default class Fill extends React.Component<Props, {}> {
   static contextTypes = {
     bus: busShape
   };


### PR DESCRIPTION
Updates to TypeScript/the React type definitions have caused issues for me when a component uses `void` instead of `{}` to indicate that a component doesn't make use of state. With default generics in `typescript@2.3` and the subsequent update over at `DefinitelyTyped` you can just omit the `void` so your class declaration looks like:
```typescript
class MyComponent extends React<MyComponentProps> {
}
```
And things will work just fine. However so the type definitions in this repo are more backwards compatible I opte to substitute `{}` in for `void` so pre `2.3` consumers don't have any issues. 


Here's the build error I get when a component uses `void`:

```
[at-loader] Checking finished with 2 errors
[at-loader] ./src/common/components/Modal/index.tsx:107:13
    TS2605: JSX element type 'Fill' is not a constructor function for JSX elements.
  Types of property 'setState' are incompatible.
    Type '{ <K extends never>(f: (prevState: void, props: Props) => Pick<void, K>, callback?: () => any): v...' is not assignable to type '{ <K extends never>(f: (prevState: {}, props: any) => Pic
k<{}, K>, callback?: () => any): void; <...'.
      Types of parameters 'f' and 'f' are incompatible.
        Types of parameters 'prevState' and 'prevState' are incompatible.
          Type 'void' is not assignable to type '{}'.

[at-loader] ./src/common/components/Modal/index.tsx:139:13
    TS2605: JSX element type 'Fill' is not a constructor function for JSX elements.
```