### PR TITLE
Update React peer dependency to 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "^15.5.8"
+    "react": "^16.0.0"
   },
   "scripts": {
     "start": "react-scripts-ts start",


### PR DESCRIPTION
Update peer dependency to v16 now that React 16 has been officially released.