### PR TITLE
chore: Remove alpha status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Slot & Fill component for merging React subtrees together.
 
-**WARNING** This library is considered alpha and has not been released check out the demos and feel free to give me feedback  star the repository and I'll get it released soon!
-
 ## Check out the [simple demo on glitch](https://rsf-demo.glitch.me/) ([view source](https://glitch.com/edit/#!/project/rsf-demo))
 
 ## Installation


### PR DESCRIPTION
Now that 2.0.0 is out the door this little snippet can be removed! :+1:. Also, is it possible to list the 2.0.0 in GitHub's releases page? It's a handy way to tell what versions the library is currently on for those of us who don't want to check NPM.